### PR TITLE
add functioning int check

### DIFF
--- a/property.go
+++ b/property.go
@@ -55,8 +55,15 @@ func (p *Property) AddRules(rules ...Rule) error {
 
 func (p Property) validate(key string, value interface{}) error {
 	valueType := reflect.TypeOf(value)
-	// make sure propType matches.
-	if valueType != p.propType {
+
+	//When Json is decoded in go, all JSON numbers are converted to float64 types.
+	// this means we need to handle integer checking differently.
+	if p.propType == Int {
+		if !valueType.ConvertibleTo(Int) {
+			return fmt.Errorf("%v: invalid type. got %v, want %v", key, valueType.String(), p.propType.String())
+		}
+
+	} else if valueType != p.propType {
 		return fmt.Errorf("%v: invalid type. got %v, want %v", key, valueType.String(), p.propType.String())
 	}
 	for _, rule := range p.rules {

--- a/property_test.go
+++ b/property_test.go
@@ -4,6 +4,51 @@ import (
 	"testing"
 )
 
+func TestProperty(t *testing.T) {
+	prop1 := NewProperty("Name", String)
+	prop2 := NewProperty("ID", Int)
+
+	//basic test.
+	err := prop1.validate("test", "test")
+	if err != nil {
+		t.Errorf("got %v wanted nil", err.Error())
+	}
+
+	// make sure int validation will still return an err
+	// when a string is passed.
+	err = prop2.validate("int test", "test")
+	if err == nil {
+		t.Error("wanted error got nil")
+	}
+
+	//confirm a float64 can be passed and verified as int.
+	err = prop2.validate("intasfloat", float64(202001))
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	enumvals := []interface{}{1, 2, 3}
+	//test rule on prop.
+	rule, err := NewEnumRule(enumvals, Int)
+	if err != nil {
+		t.Errorf("could not build rule for testing. err: %v", err.Error())
+	}
+	err = prop2.AddRules(rule)
+	if err != nil {
+		t.Errorf("could not place rule on prop. %v", err.Error())
+	}
+
+	err = prop2.validate("int", 1)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	err = prop2.validate("int fail ", 12)
+	if err == nil {
+		t.Errorf("got nil wanted error")
+	}
+}
+
 func TestComplextProperty(t *testing.T) {
 	// build properties.
 	prop1 := NewProperty("Name", String)


### PR DESCRIPTION
previously it was impossible for an Int property to be validated because the json decoder decodes JSON numbers to float64 go types. This PR updates the validation process to see if the float64 can be converted to an int type.