### PR TITLE
Optionshandling

### DIFF
--- a/myapi.go
+++ b/myapi.go
@@ -16,20 +16,22 @@ type MyAPI struct {
 	subrouters       []SubRouter
 	Routes           []Route
 	globalmiddleware []Middleware
-	managedRouter    mux.Router
+	managedRouter    *mux.Router
 	Port             string
+	cors             bool
 	routeProps       map[string]PropertyGroup
 }
 
 //NewMyAPI creates a new MyAPI instance.
-func NewMyAPI(name string, port string) MyAPI {
+func NewMyAPI(name string, port string, cors bool) MyAPI {
 	myapi := MyAPI{
 		Name:       name,
 		Port:       port,
+		cors:       cors,
 		routeProps: make(map[string]PropertyGroup),
 	}
-	mux := mux.NewRouter()
-	myapi.managedRouter = *mux
+	r := mux.NewRouter()
+	myapi.managedRouter = r
 	return myapi
 }
 
@@ -59,6 +61,9 @@ func (m *MyAPI) UseSubrouter(sr SubRouter) error {
 	for _, mw := range sr.middleware {
 		sub.Use(mw.handler)
 	}
+	if m.cors {
+		sub.Use(mux.CORSMethodMiddleware(sub))
+	}
 	m.subrouters = append(m.subrouters, sr)
 	return nil
 }
@@ -79,14 +84,14 @@ func (m *MyAPI) UseRoute(r Route) error {
 //StartServer starts the server using the port and managed routers.
 func (m *MyAPI) StartServer() error {
 	m.build()
-	return http.ListenAndServe(m.Port, &m.managedRouter)
+	return http.ListenAndServe(m.Port, m.managedRouter)
 }
 
 //StartTestServer starts the server using httptest.NewServer() instead of
 // http.ListenAndServe for testing purposes.
 func (m *MyAPI) StartTestServer() (*httptest.Server, error) {
 	m.build()
-	return httptest.NewServer(&m.managedRouter), nil
+	return httptest.NewServer(m.managedRouter), nil
 }
 
 //myapiMiddleware middleware function used to implement all type checking and rule
@@ -131,6 +136,9 @@ func (m *MyAPI) myapiMiddleware(next http.Handler) http.Handler {
 //build adds anything to myapi that is needed for it to run, but needs to be set
 //after all routes and middleware have been added.
 func (m *MyAPI) build() error {
+	if m.cors {
+		m.managedRouter.Use(mux.CORSMethodMiddleware(m.managedRouter))
+	}
 	m.managedRouter.Use(m.myapiMiddleware)
 	return nil
 }

--- a/myapi.go
+++ b/myapi.go
@@ -49,7 +49,7 @@ func (m *MyAPI) UseSubrouter(sr SubRouter) error {
 	for _, route := range sr.routes {
 		if _, present := m.routeProps[sr.prefix+route.path]; !present {
 			m.routeProps[sr.prefix+route.path] = route.props
-			sub.Handle(route.path, route.handler).Methods(route.method)
+			sub.Handle(route.path, route.handler).Methods(route.method...)
 		} else {
 			return fmt.Errorf("duplicated route: %v", sr.prefix+route.path)
 		}
@@ -69,7 +69,7 @@ func (m *MyAPI) UseRoute(r Route) error {
 
 	if _, present := m.routeProps[r.path]; !present {
 		m.routeProps[r.path] = r.props
-		m.managedRouter.Handle(r.path, r.handler).Methods(r.method)
+		m.managedRouter.Handle(r.path, r.handler).Methods(r.method...)
 		return nil
 	}
 	return fmt.Errorf("duplicated route: %v", r.path)

--- a/myapi_test.go
+++ b/myapi_test.go
@@ -104,9 +104,9 @@ func returnnil() error {
 func buildtestserver() MyAPI {
 
 	testserver := NewMyAPI("test", ":8080")
-	route := NewRoute("/plainroute", http.MethodGet, func(w http.ResponseWriter, r *http.Request) {
+	route := NewRoute("/plainroute", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("plainroute"))
-	})
+	}, http.MethodGet)
 	err := testserver.UseRoute(route)
 	if err != nil {
 		panic(err)
@@ -130,9 +130,9 @@ func buildtestserver() MyAPI {
 
 	//create Properties and a route to test them on.
 	prop := NewProperty("Test", String)
-	propRouteTest := NewRoute("/proptest", http.MethodPost, func(w http.ResponseWriter, r *http.Request) {
+	propRouteTest := NewRoute("/proptest", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("proptest"))
-	})
+	}, http.MethodPost)
 
 	err = propRouteTest.AddProperty(prop)
 	if err != nil {

--- a/myapi_test.go
+++ b/myapi_test.go
@@ -77,6 +77,10 @@ func TestMyAPI(t *testing.T) {
 			return fmt.Errorf("wrong status code: got %v want %v", res.StatusCode, 200)
 		}
 
+		if head := res.Header.Get("Access-Control-Allow-Methods"); head == "" {
+			return errors.New("cors fail: Access-Control-Allow-Methods header not set")
+		}
+
 		return nil
 	}
 
@@ -103,10 +107,10 @@ func returnnil() error {
 }
 func buildtestserver() MyAPI {
 
-	testserver := NewMyAPI("test", ":8080")
+	testserver := NewMyAPI("test", ":8080", true)
 	route := NewRoute("/plainroute", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("plainroute"))
-	}, http.MethodGet)
+	}, http.MethodGet, http.MethodOptions)
 	err := testserver.UseRoute(route)
 	if err != nil {
 		panic(err)
@@ -132,7 +136,7 @@ func buildtestserver() MyAPI {
 	prop := NewProperty("Test", String)
 	propRouteTest := NewRoute("/proptest", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("proptest"))
-	}, http.MethodPost)
+	}, http.MethodPost, http.MethodOptions)
 
 	err = propRouteTest.AddProperty(prop)
 	if err != nil {

--- a/route.go
+++ b/route.go
@@ -6,14 +6,14 @@ import "net/http"
 type Route struct {
 	path        string
 	description string
-	method      string
+	method      []string
 	handler     http.HandlerFunc
 	props       PropertyGroup
 }
 
 //NewRoute takes in all neccesay parts of a route: path method and handler function.
 // other fields can be set via other functions.
-func NewRoute(path, method string, Handler http.HandlerFunc) Route {
+func NewRoute(path string, Handler http.HandlerFunc, method ...string) Route {
 	pg := PropertyGroup{
 		properties: make(map[string]Props),
 	}

--- a/router_test.go
+++ b/router_test.go
@@ -9,10 +9,10 @@ import (
 func TestRouter(t *testing.T) {
 	testrouter := NewSubRouter("/v1")
 
-	route := NewRoute("/test", http.MethodPost,
+	route := NewRoute("/test",
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			fmt.Println("hello")
-		}))
+		}), http.MethodPost)
 	testrouter.AddRoute(route)
 
 	if len(testrouter.routes) != 1 {


### PR DESCRIPTION
changes route to allow for multiple http methods on the same route and makes it easy to add Access-Control-Allow-Methods header using mux.CORSmiddleware. other cors headers will still need to be added. 